### PR TITLE
Migrate APIv1 to APIv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This action enables the integration of PagerDuty into StackStorm. It is capable of performing the following actions:
 
-1. List all the open incidents on PD for a subdomain
+1. List all the open incidents on PD (for a given api key)
 2. Send acknowledgment of any incident(s)
 3. Close and open incident(s)
 4. Launch an incident by giving its details and description
@@ -12,7 +12,6 @@ This action enables the integration of PagerDuty into StackStorm. It is capable 
 Copy the example configuration in [pagerduty.yaml.example](./pagerduty.yaml.example)
 to `/opt/stackstorm/configs/pagerduty.yaml` and edit as required.
 
-* `subdomain:` name of subdomain
 * `api_key:` API-KEY
 * `service_api:` SERVICE-API
 * `debug:` optional debug flag. Set to True for additional logging

--- a/README.md
+++ b/README.md
@@ -3,13 +3,39 @@
 This action enables the integration of PagerDuty into StackStorm. It is capable of performing the following actions:
 
 1. List all the open incidents on PD (for a given api key)
-2. Send acknowledgment of any incident(s)
-3. Close and open incident(s)
-4. Launch an incident by giving its details and description
+
+```
+st2 run pagerduty.get_open_incidents
+```
+
+2. Launch an incident by giving its details and description
+
+```
+st2 run pagerduty.launch_incident description='<incident title>'
+```
+
+3. Send acknowledgment of any incident(s)
+
+```
+st2 run pagerduty.ack_incident email='<email>' ids=<comma separated list of incident ids>
+```
+
+4. Resolve acknowledged incident(s)
+
+```
+st2 run pagerduty.resolve_incident email='<email>' ids=<comma separated list of incident ids>
+```
 
 # Configuration
 
-Copy the example configuration in [pagerduty.yaml.example](./pagerduty.yaml.example)
+To create and install the config file, you can run:
+
+```
+st2 pack config pagerduty
+```
+
+Alternatively, you can copy the example configuration in
+[pagerduty.yaml.example](./pagerduty.yaml.example)
 to `/opt/stackstorm/configs/pagerduty.yaml` and edit as required.
 
 * `api_key:` API-KEY

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Alternatively, you can copy the example configuration in
 to `/opt/stackstorm/configs/pagerduty.yaml` and edit as required.
 
 * `api_key:` API-KEY
-* `service_api:` SERVICE-API
+* `service_key:` SERVICE-KEY
 * `debug:` optional debug flag. Set to True for additional logging
 
 You can also use dynamic values from the datastore. See the

--- a/actions/ack_incident.py
+++ b/actions/ack_incident.py
@@ -2,11 +2,11 @@ from lib.action import PagerDutyAction
 
 
 class AckIncident(PagerDutyAction):
-    def run(self, email, keys):
+    def run(self, email, ids):
         """
         Acknowledgment of a trigger. The PagerDuty v2 API requires that
-        an incident be acknowledged using a valid email address. keys is
-        an array of incident keys.
+        an incident be acknowledged using a valid email address. ids is
+        an array of incident ids.
         """
 
         # TODO: Do we need to optionally be able to specify the service key?
@@ -14,9 +14,9 @@ class AckIncident(PagerDutyAction):
         if email is None:
             raise ValueError("email must be specified")
 
-        for key in keys:
-            query_params = {'id': key}
+        for id in ids:
+            query_params = {'id': id}
             incident = self.pager.Incident.fetch(limit=1, **query_params)
             incident.acknowledge(from_email=email)
 
-        return keys
+        return ids

--- a/actions/ack_incident.py
+++ b/actions/ack_incident.py
@@ -15,7 +15,7 @@ class AckIncident(PagerDutyAction):
             raise ValueError("email must be specified")
 
         for key in keys:
-            query_params = { 'id': key }
+            query_params = {'id': key}
             incident = self.pager.Incident.fetch(limit=1, **query_params)
             incident.acknowledge(from_email=email)
 

--- a/actions/ack_incident.py
+++ b/actions/ack_incident.py
@@ -2,13 +2,20 @@ from lib.action import PagerDutyAction
 
 
 class AckIncident(PagerDutyAction):
-    def run(self, event_keys):
+    def run(self, **param_dict):
         """
-        Acknowledgment of a trigger, You can provide comma(,) separated keys
-        for acknowledging more than one event at a time.
+        Acknowledgment of a trigger. The PagerDuty v2 API requires that
+        an incident be acknowledged using a valid email address. param_dict
+        is a dictionary with key = incident_key, and value = email.
         """
 
-        for arg in event_keys:
-            self.pager.acknowledge_incident(self.config['service_api'], arg)
+        # TODO: Do we need to optionally be able to specify the service key?
 
-        return event_keys
+        for incident_key, email in param_dict.iteritems():
+            if email is None:
+                raise ValueError("%s has empty email", incident_key)
+            else:
+                incident = self.pager.Incident.find_one(incident_key)
+                incident.acknowledge(from_email=email)
+
+        return param_dict.keys()

--- a/actions/ack_incident.py
+++ b/actions/ack_incident.py
@@ -4,8 +4,8 @@ from lib.action import PagerDutyAction
 class AckIncident(PagerDutyAction):
     def run(self, event_keys):
         """
-        Acknowledgment of a trigger, You can provide comma(,) separated keys for acknowledging more
-        events at once.
+        Acknowledgment of a trigger, You can provide comma(,) separated keys
+        for acknowledging more than one event at a time.
         """
 
         for arg in event_keys:

--- a/actions/ack_incident.py
+++ b/actions/ack_incident.py
@@ -2,20 +2,20 @@ from lib.action import PagerDutyAction
 
 
 class AckIncident(PagerDutyAction):
-    def run(self, **param_dict):
+    def run(self, email, keys):
         """
         Acknowledgment of a trigger. The PagerDuty v2 API requires that
-        an incident be acknowledged using a valid email address. param_dict
-        is a dictionary with key = incident_key, and value = email.
+        an incident be acknowledged using a valid email address. keys is
+        an array of incident keys.
         """
 
         # TODO: Do we need to optionally be able to specify the service key?
 
-        for incident_key, email in param_dict.iteritems():
-            if email is None:
-                raise ValueError("%s has empty email", incident_key)
-            else:
-                incident = self.pager.Incident.find_one(incident_key)
-                incident.acknowledge(from_email=email)
+        if email is None:
+            raise ValueError("email must be specified")
 
-        return param_dict.keys()
+        for key in keys:
+            incident = self.pager.Incident.find_one(key)
+            incident.acknowledge(from_email=email)
+
+        return keys

--- a/actions/ack_incident.py
+++ b/actions/ack_incident.py
@@ -15,7 +15,8 @@ class AckIncident(PagerDutyAction):
             raise ValueError("email must be specified")
 
         for key in keys:
-            incident = self.pager.Incident.find_one(key)
+            query_params = { 'id': key }
+            incident = self.pager.Incident.fetch(limit=1, **query_params)
             incident.acknowledge(from_email=email)
 
         return keys

--- a/actions/ack_incident.yaml
+++ b/actions/ack_incident.yaml
@@ -4,7 +4,9 @@ description: Acknowledge an incident on PagerDuty
 enabled: true
 entry_point: ack_incident.py
 parameters:
-  param_dict:
-    type: object
-    description: Dictionary containing (incident_key, email)
-
+  keys:
+    type: array
+    description: Array of incident keys
+  email:
+    type: string
+    description: Email address used to acknowledge the incident

--- a/actions/ack_incident.yaml
+++ b/actions/ack_incident.yaml
@@ -1,10 +1,10 @@
 name: ack_incident
 runner_type: run-python
-description: ACK an incident on PagerDuty
+description: Acknowledge an incident on PagerDuty
 enabled: true
 entry_point: ack_incident.py
 parameters:
-  event_keys:
-    type: array
-    description: Key for event to be acknowledged, You can also Provide comma separated keys 
+  param_dict:
+    type: object
+    description: Dictionary containing (incident_key, email)
 

--- a/actions/ack_incident.yaml
+++ b/actions/ack_incident.yaml
@@ -1,12 +1,12 @@
 name: ack_incident
 runner_type: run-python
-description: Acknowledge an incident on PagerDuty
+description: Acknowledge an incident whose id is provided
 enabled: true
 entry_point: ack_incident.py
 parameters:
-  keys:
+  ids:
     type: array
-    description: Array of incident keys
+    description: Array of incident ids
   email:
     type: string
     description: Email address used to acknowledge the incident

--- a/actions/launch_incident.py
+++ b/actions/launch_incident.py
@@ -2,8 +2,12 @@ from lib.action import PagerDutyAction
 
 
 class LaunchIncident(PagerDutyAction):
-    def run(self, description, details=None):
-        """lauch a trigger """
-        lst = self.pager.trigger_incident(self.config['service_api'], description=description,
-                                          details=details)
-        return lst
+    def run(self, description, event_type='trigger', details=None):
+        """Create a trigger"""
+        result = self.pager.Incident.create(data={
+            'service_key': self.config['service_key'],
+            'event_type': event_type,
+            'description': description,
+            'details': details}
+        )
+        return result

--- a/actions/launch_incident.py
+++ b/actions/launch_incident.py
@@ -5,7 +5,7 @@ class LaunchIncident(PagerDutyAction):
     def run(self, description, event_type='trigger', details=None):
         """Create a trigger"""
 
-        payload={
+        payload = {
             'service_key': self.config['service_key'],
             'event_type': event_type,
             'description': description,

--- a/actions/launch_incident.py
+++ b/actions/launch_incident.py
@@ -4,10 +4,12 @@ from lib.action import PagerDutyAction
 class LaunchIncident(PagerDutyAction):
     def run(self, description, event_type='trigger', details=None):
         """Create a trigger"""
-        result = self.pager.Incident.create(data={
+
+        result = self.pager.Event.create(data={
             'service_key': self.config['service_key'],
             'event_type': event_type,
             'description': description,
-            'details': details}
-        )
+            'details': details
+        })
+
         return result

--- a/actions/launch_incident.py
+++ b/actions/launch_incident.py
@@ -5,11 +5,14 @@ class LaunchIncident(PagerDutyAction):
     def run(self, description, event_type='trigger', details=None):
         """Create a trigger"""
 
-        result = self.pager.Event.create(data={
+        payload={
             'service_key': self.config['service_key'],
             'event_type': event_type,
             'description': description,
-            'details': details
-        })
+        }
+        if details is not None:
+            payload['details'] = details
+
+        result = self.pager.Event.create(data=payload)
 
         return result

--- a/actions/launch_incident.yaml
+++ b/actions/launch_incident.yaml
@@ -7,7 +7,6 @@ parameters:
   details:
     type: string
     description: Details of the incident 
-    
   description:
     type: string
     description: Description of the incident

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -13,7 +13,7 @@ class PagerDutyAction(Action):
     def _init_client(self):
         """ init_client method, run at class creation """
         pypd.api_key = self.config['api_key']
-        pypd.service_api = self.config['service_api']
+        pypd.service_key = self.config['service_key']
         return pypd
 
     def get_ack_incidents(self):

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -5,25 +5,27 @@ from st2actions.runners.pythonrunner import Action
 
 class PagerDutyAction(Action):
     def __init__(self, config):
+        """ init method, run at class creation """
         super(PagerDutyAction, self).__init__(config)
         self.pager = self._init_client()
         self.trigger = []
 
     def _init_client(self):
-        # TODO: Return pager object
+        """ init_client method, run at class creation """
         pypd.api_key = self.config['api_key']
+        pypd.service_api = self.config['service_api']
         return pypd
 
-    #  get all the acknowledged incidents
     def get_ack_incidents(self):
+        """ Get all the acknowledged incidents """
         ack_alarms = []
-        for incident in self.pager.incidents.list(status="acknowledged"):
+        for incident in self.pager.Incident.find(statuses=['acknowledged']):
             ack_alarms.append(incident.incident_key)
         return ack_alarms
 
-    #  get all the triggered incidents
     def get_triggered_incidents(self):
+        """ Get all the triggered incidents """
         trigger_alarms = []
-        for incident in self.pager.incidents.list(status="triggered"):
+        for incident in self.pager.Incident.find(statuses=['triggered']):
             trigger_alarms.append(incident.incident_key)
         return trigger_alarms

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -1,4 +1,4 @@
-import pygerduty
+import pypd
 
 from st2actions.runners.pythonrunner import Action
 
@@ -10,11 +10,9 @@ class PagerDutyAction(Action):
         self.trigger = []
 
     def _init_client(self):
-        api_key = self.config['api_key']
-        #  service_api = self.config['service_api']
-        subdomain = self.config['subdomain']
-        pager = pygerduty.PagerDuty(subdomain, api_token=api_key)
-        return pager
+        # TODO: Return pager object
+        pypd.api_key = self.config['api_key']
+        return pypd
 
     #  get all the acknowledged incidents
     def get_ack_incidents(self):

--- a/actions/open_incidents.py
+++ b/actions/open_incidents.py
@@ -7,7 +7,7 @@ class OpenIncident(PagerDutyAction):
         open_incident = {}
         open_incident_list = []
         for incident in self.pager.Incident.find(statuses=['triggered', 'acknowledged']):
-            open_incident = {'key': incident['incident_key'], 'status': incident['status'],
+            open_incident = {'key': incident['id'], 'status': incident['status'],
                              'desc': incident['description']}
             open_incident_list.append(open_incident)
         return open_incident_list

--- a/actions/open_incidents.py
+++ b/actions/open_incidents.py
@@ -3,11 +3,11 @@ from lib.action import PagerDutyAction
 
 class OpenIncident(PagerDutyAction):
     def run(self):
-        """List all Open incidents """
+        """List all open incidents, that is, incident.status = 'triggered' or 'acknowledged'"""
         open_incident = {}
         open_incident_list = []
-        for incident in self.pager.incidents.list(status="triggered,acknowledged"):
-            open_incident = {'key': incident.incident_key, 'status': incident.status,
-                             'desc': incident.trigger_summary_data.description}
+        for incident in self.pager.Incident.find(statuses=['triggered', 'acknowledged']):
+            open_incident = {'key': incident['incident_key'], 'status': incident['status'],
+                             'desc': incident['description']}
             open_incident_list.append(open_incident)
         return open_incident_list

--- a/actions/resolve_incident.py
+++ b/actions/resolve_incident.py
@@ -12,10 +12,11 @@ class ResolveIncident(PagerDutyAction):
         # TODO: Do we need to be able to optionally specify the service key?
 
         if email is None:
-            raise ValueError("email must be specified", email)
+            raise ValueError("email must be specified")
 
         for key in keys:
-            incident = self.pager.Incident.find_one(key)
+            query_params = { 'id': key }
+            incident = self.pager.Incident.fetch(limit=1, **query_params)
             incident.resolve(from_email=email)
 
         return keys

--- a/actions/resolve_incident.py
+++ b/actions/resolve_incident.py
@@ -2,20 +2,20 @@ from lib.action import PagerDutyAction
 
 
 class ResolveIncident(PagerDutyAction):
-    def run(self, **param_dict):
+    def run(self, email, keys):
         """
         Resolve an incident. The PagerDuty v2 API requires that an incident
-        be resolved using a valid email address. param_dict is a dictionary
-        with key = incident_key, and value = email.
+        be resolved using a valid email address. keys is an array of
+        incident keys.
         """
 
         # TODO: Do we need to be able to optionally specify the service key?
 
-        for incident_key, email in param_dict.iteritems():
-            if email is None:
-                raise ValueError("%s has empty email", incident_key)
-            else:
-                incident = self.pager.Incident.find_one(incident_key)
-                incident.resolve(from_email=email)
+        if email is None:
+            raise ValueError("email must be specified", email)
 
-        return param_dict.keys()
+        for key in keys:
+            incident = self.pager.Incident.find_one(key)
+            incident.resolve(from_email=email)
+
+        return keys

--- a/actions/resolve_incident.py
+++ b/actions/resolve_incident.py
@@ -2,12 +2,20 @@ from lib.action import PagerDutyAction
 
 
 class ResolveIncident(PagerDutyAction):
-    def run(self, event_keys):
+    def run(self, **param_dict):
         """
-        Resolve an incident, You can provide comma(,) separated keys for resolving more events at
-        once.
+        Resolve an incident. The PagerDuty v2 API requires that an incident
+        be resolved using a valid email address. param_dict is a dictionary
+        with key = incident_key, and value = email.
         """
-        for arg in event_keys:
-            self.pager.resolve_incident(self.config['service_api'], arg)
 
-        return event_keys
+        # TODO: Do we need to be able to optionally specify the service key?
+
+        for incident_key, email in param_dict.iteritems():
+            if email is None:
+                raise ValueError("%s has empty email", incident_key)
+            else:
+                incident = self.pager.Incident.find_one(incident_key)
+                incident.resolve(from_email=email)
+
+        return param_dict.keys()

--- a/actions/resolve_incident.py
+++ b/actions/resolve_incident.py
@@ -15,7 +15,7 @@ class ResolveIncident(PagerDutyAction):
             raise ValueError("email must be specified")
 
         for key in keys:
-            query_params = { 'id': key }
+            query_params = {'id': key}
             incident = self.pager.Incident.fetch(limit=1, **query_params)
             incident.resolve(from_email=email)
 

--- a/actions/resolve_incident.py
+++ b/actions/resolve_incident.py
@@ -2,11 +2,11 @@ from lib.action import PagerDutyAction
 
 
 class ResolveIncident(PagerDutyAction):
-    def run(self, email, keys):
+    def run(self, email, ids):
         """
         Resolve an incident. The PagerDuty v2 API requires that an incident
-        be resolved using a valid email address. keys is an array of
-        incident keys.
+        be resolved using a valid email address. ids is an array of
+        incident ids.
         """
 
         # TODO: Do we need to be able to optionally specify the service key?
@@ -14,9 +14,9 @@ class ResolveIncident(PagerDutyAction):
         if email is None:
             raise ValueError("email must be specified")
 
-        for key in keys:
-            query_params = {'id': key}
+        for id in ids:
+            query_params = {'id': id}
             incident = self.pager.Incident.fetch(limit=1, **query_params)
             incident.resolve(from_email=email)
 
-        return keys
+        return ids

--- a/actions/resolve_incident.yaml
+++ b/actions/resolve_incident.yaml
@@ -1,12 +1,12 @@
 name: resolve_incident
 runner_type: run-python
-description: Resolve an incident whose key is provided
+description: Resolve an incident whose id is provided
 enabled: true
 entry_point: resolve_incident.py
 parameters:
-  keys:
+  ids:
     type: array
-    description: Array of incident keys
+    description: Array of incident ids
   email:
     type: string
     description: Email address used to acknowledge the incident

--- a/actions/resolve_incident.yaml
+++ b/actions/resolve_incident.yaml
@@ -4,7 +4,9 @@ description: Resolve an incident whose key is provided
 enabled: true
 entry_point: resolve_incident.py
 parameters:
-  param_dict:
-    type: object
-    description: Dictionary containing (incident_key, email)
-
+  keys:
+    type: array
+    description: Array of incident keys
+  email:
+    type: string
+    description: Email address used to acknowledge the incident

--- a/actions/resolve_incident.yaml
+++ b/actions/resolve_incident.yaml
@@ -4,7 +4,7 @@ description: Resolve an incident whose key is provided
 enabled: true
 entry_point: resolve_incident.py
 parameters:
-  event_keys:
-    type: array
-    description: Key for event to be resolved, You can also Provide comma separated keys
+  param_dict:
+    type: object
+    description: Dictionary containing (incident_key, email)
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,9 +1,4 @@
 ---
-  subdomain:
-    description: "PagerDuty subdomain"
-    type: "string"
-    secret: false
-    required: true
   api_key:
     description: "API Key"
     type: "string"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,11 +1,11 @@
 ---
   api_key:
-    description: "API Key"
+    description: "PagerDuty API Key"
     type: "string"
     secret: true
     required: true
-  service_api:
-    description: "Service API"
+  service_key:
+    description: "PagerDuty Service Key"
     type: "string"
     secret: true
     required: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: pagerduty
 name: pagerduty
 description: Packs which allows integration with PagerDuty services.
-version: 0.2.0
+version: 0.3.0
 author: Aamir
 email: raza.aamir01@gmail.com

--- a/pagerduty.yaml.example
+++ b/pagerduty.yaml.example
@@ -1,4 +1,4 @@
 ---
 api_key: MmzGEJKsqmq7DrmE4w1R
-service_api: 1148e87e51fe4688aaba21b88b264692
+service_key: 1148e87e51fe4688aaba21b88b264692
 debug: false

--- a/pagerduty.yaml.example
+++ b/pagerduty.yaml.example
@@ -1,5 +1,4 @@
 ---
-subdomain: 'devarchs'
 api_key: MmzGEJKsqmq7DrmE4w1R
 service_api: 1148e87e51fe4688aaba21b88b264692
 debug: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pygerduty==0.25
+pypd==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pypd==0.1.0
+urllib3[secure]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 pypd==0.1.0
-urllib3[secure]


### PR DESCRIPTION
First set of changes to support PagerDuty APIv2

The individual API calls should work and have been verified against the PagerDuty APIv2. However, I have not tested these calls running as an st2 pack.