### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.3.0
 
 - Migrate from pygerduty (APIv1) to pypd (APIv2)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ to `/opt/stackstorm/configs/pagerduty.yaml` and edit as required.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Retrieving API Key from PagerDuty
 
 * Sign into PagerDuty

--- a/actions/ack_incident.yaml
+++ b/actions/ack_incident.yaml
@@ -1,5 +1,5 @@
 name: ack_incident
-runner_type: run-python
+runner_type: python-script
 description: Acknowledge an incident whose id is provided
 enabled: true
 entry_point: ack_incident.py

--- a/actions/launch_incident.yaml
+++ b/actions/launch_incident.yaml
@@ -1,5 +1,5 @@
 name: launch_incident 
-runner_type: run-python
+runner_type: python-script
 description: Launch an incident on PagerDuty
 enabled: true
 entry_point: launch_incident.py

--- a/actions/open_incidents.yaml
+++ b/actions/open_incidents.yaml
@@ -1,5 +1,5 @@
 name: get_open_incidents
-runner_type: run-python
+runner_type: python-script
 description: Retrive list of open incidents from PagerDuty
 enabled: true
 entry_point: open_incidents.py

--- a/actions/resolve_incident.yaml
+++ b/actions/resolve_incident.yaml
@@ -1,5 +1,5 @@
 name: resolve_incident
-runner_type: run-python
+runner_type: python-script
 description: Resolve an incident whose id is provided
 enabled: true
 entry_point: resolve_incident.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: pagerduty
 name: pagerduty
 description: Packs which allows integration with PagerDuty services.
-version: 0.3.0
+version: 0.4.0
 author: Aamir
 email: raza.aamir01@gmail.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.